### PR TITLE
Fixing design flow selection

### DIFF
--- a/HydroGenerate/turbine_calculation.py
+++ b/HydroGenerate/turbine_calculation.py
@@ -344,9 +344,9 @@ class PercentExceedance(DesignFlow):
             design_flow = flow      # when a single value of flow is provided, this is the design flow
 
         else:
-            pc_e = np.linspace(100, 1, 100)     # sequence from 100 to 1.
+            pc_e = np.linspace(100, 0, 101)     # sequence from 100 to 1.
             flow = flow[~np.isnan(flow)] # remove nan values
-            flow_percentiles = np.percentile(flow, q = np.linspace(1, 100, 100))        # percentiles to compute, 1:100
+            flow_percentiles = np.percentile(flow, q = np.linspace(0, 100, 101))        # percentiles to compute, 1:100
             flowduration_curve = {'Flow': flow_percentiles, 'Percent_Exceedance':pc_e}      # Flow duration curve
             design_flow = float(flowduration_curve['Flow'][flowduration_curve['Percent_Exceedance'] == pe])     # flow for the selected percent of excedante
             turbine.flowduration_curve = pd.DataFrame(data = flowduration_curve)


### PR DESCRIPTION
The percent of exceedance was being subtracted 1.  Example, when selecting pcrf = 30 (default), HG was using pcrf -= 29. This update fixes that.